### PR TITLE
Add ZMCDN functionality to mainline

### DIFF
--- a/ZMachine.ts
+++ b/ZMachine.ts
@@ -1657,7 +1657,7 @@ class ZMachine {
           }
           return;
         case 12: // show_status
-          console.log("@show_status");
+//          console.log("@show_status");
           return;
       }
     }

--- a/tszm.ts
+++ b/tszm.ts
@@ -1,17 +1,131 @@
 import { ZMachine } from "./ZMachine";
 import { ZMInputOutputDevice } from "./ZMInputOutputDevice";
 import * as readline from "readline";
+import * as crypto from "crypto";
+import * as http from "http";
 
 // A simple console-based implementation of ZMInputOutputDevice
 class ZMConsole implements ZMInputOutputDevice {
   private history: string[] = [];
   private historyIndex: number = 0;
+  private ZMCDNText: string = "";
+  private zm: ZMachine | null = null;
+  private zmcdnEnabled: boolean = false;
+  private zmcdnServer: string = "";
 
-  constructor() {
+  constructor(zmcdnServer?: string) {
     readline.emitKeypressEvents(process.stdin);
+    if (zmcdnServer) {
+      this.zmcdnServer = zmcdnServer;
+      this.zmcdnEnabled = true;
+    }
+  }
+
+  setZMachine(zm: ZMachine): void {
+    this.zm = zm;
+  }
+
+  async processZMCDNText(): Promise<void> {
+    if (this.ZMCDNText && this.zmcdnEnabled) {
+      const text = this.ZMCDNText;
+      this.ZMCDNText = "";
+
+      // Compute SHA512 hash
+      const hash = crypto.createHash("sha512").update(text).digest("hex");
+
+      // Get gameId from header
+      if (!this.zm) {
+        console.error("ZMachine not initialized");
+        return;
+      }
+
+      const header = this.zm.getHeader();
+      if (!header) {
+        console.error("Unable to read game header");
+        return;
+      }
+      const gameId = `${header.release}.${header.serial}`;
+
+      // Make HTTP GET request
+      const url = `${this.zmcdnServer}/print/${gameId}/${hash}/sixel`;
+
+      try {
+        const data = await this.fetchURL(url);
+        console.error(`Received ${data.length} bytes of sixel data`);
+        // Dump sixel-formatted graphics to terminal
+        process.stdout.write(data);
+        process.stdout.write('\n');
+      } catch (error) {
+        // On failure, POST to generate endpoint
+        try {
+          await this.postGenerate(gameId, text);
+          // If generation succeeds, re-request the image
+          const data = await this.fetchURL(url);
+          console.error(`Received ${data.length} bytes of sixel data after generation`);
+          process.stdout.write(data);
+          process.stdout.write('\n');
+        } catch (postError) {
+          console.error(`Failed to fetch graphics from ${url}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+    }
+    return Promise.resolve();
+  }
+
+  private fetchURL(url: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      http.get(url, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => { data += chunk; });
+        res.on("end", () => resolve(data));
+      }).on("error", reject);
+    });
+  }
+
+  private postGenerate(gameId: string, text: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const postData = JSON.stringify({
+        gameID: gameId,
+        text: text
+      });
+
+      const url = new URL(`${this.zmcdnServer}/generate`);
+      const options = {
+        hostname: url.hostname,
+        port: url.port || (url.protocol === "https:" ? 443 : 80),
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(postData)
+        }
+      };
+
+      const req = http.request(options, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+        res.resume();
+        resolve();
+      });
+
+      req.on("error", reject);
+      req.write(postData);
+      req.end();
+    });
   }
 
   async readChar(): Promise<string> {
+    await this.processZMCDNText();
     return new Promise((resolve) => {
       process.stdin.once("data", (data) => {
         resolve(data.toString().charAt(0));
@@ -20,6 +134,7 @@ class ZMConsole implements ZMInputOutputDevice {
   }
 
   async readLine(): Promise<string> {
+    await this.processZMCDNText();
     return new Promise((resolve) => {
       let input = "";
       let cursorPos = 0;
@@ -43,6 +158,22 @@ class ZMConsole implements ZMInputOutputDevice {
             process.stdin.setRawMode(false);
           }
           process.stdout.write("\n");
+
+          // Check for ZMCDN commands
+          const zmcdnMatch = input.trim().match(/^\/zmcdn\s+(.+)$/);
+          if (zmcdnMatch) {
+            const arg = zmcdnMatch[1];
+            if (arg === "off") {
+              this.zmcdnEnabled = false;
+              console.log("ZMCDN image fetching disabled");
+            } else {
+              this.zmcdnServer = arg;
+              this.zmcdnEnabled = true;
+              console.log(`ZMCDN image fetching enabled with server: ${arg}`);
+            }
+            return this.readLine().then(resolve);
+          }
+
           if (input.trim()) {
             this.history.push(input);
           }
@@ -172,10 +303,12 @@ class ZMConsole implements ZMInputOutputDevice {
   }
 
   async writeChar(char: string): Promise<void> {
+    this.ZMCDNText += char;
     process.stdout.write(char);
   }
 
   async writeString(str: string): Promise<void> {
+    this.ZMCDNText += str;
     process.stdout.write(str);
   }
 
@@ -190,11 +323,19 @@ async function main() {
   // Parse command line arguments
   const args = process.argv.slice(2);
   const traceEnabled = args.includes("--trace");
-  const zImagePath = args.find(arg => !arg.startsWith("--"));
+
+  // Find --zmcdn argument
+  let zmcdnServer: string | undefined;
+  const zmcdnIndex = args.indexOf("--zmcdn");
+  if (zmcdnIndex !== -1 && zmcdnIndex + 1 < args.length) {
+    zmcdnServer = args[zmcdnIndex + 1];
+  }
+
+  const zImagePath = args.find(arg => !arg.startsWith("--") && arg !== zmcdnServer);
 
   if (!zImagePath) {
     console.error("Error: Z-image file path is required");
-    console.error("Usage: tszm <z-image-file> [--trace]");
+    console.error("Usage: tszm <z-image-file> [--trace] [--zmcdn <server-url>]");
     process.exit(1);
   }
 
@@ -204,7 +345,7 @@ async function main() {
     process.exit(0);
   });
 
-  const consoleDevice = new ZMConsole();
+  const consoleDevice = new ZMConsole(zmcdnServer);
   const zm = new ZMachine(zImagePath, consoleDevice);
 
   if (traceEnabled) {
@@ -213,6 +354,7 @@ async function main() {
 
   try {
     await zm.load();
+    consoleDevice.setZMachine(zm);
     console.log("Header:", zm.getHeader());
     console.log("Starting execution...");
 


### PR DESCRIPTION
Beginning of ZMCDN client functionality. Can toggle through slash-commands in the interpreter, also specify the ZMCDN URL from command line. Output is Sixel graphics.
