### PR TITLE
implement unit testing and coverage report automation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,13 +69,13 @@ jobs:
           NODE
 
       - name: Upload Pages artifact (coverage site)
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && matrix.node-version == '20.x' }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: coverage/lcov-report
 
       - name: Deploy coverage to GitHub Pages
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && matrix.node-version == '20.x' }}
         uses: actions/deploy-pages@v4
 
       - name: Add coverage link to summary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,19 @@ jobs:
           console.log(line('functions'));
           console.log(line('lines'));
           NODE
+          
+      - name: Stage Pages content under /coverage
+        if: ${{ !env.ACT && matrix.node-version == '20.x' }}
+        run: |
+          rm -rf site
+          mkdir -p site/coverage
+          cp -r coverage/lcov-report/* site/coverage/
+          cat > site/index.html <<'HTML'
+          <!doctype html><meta charset="utf-8">
+          <title>Coverage</title>
+          <meta http-equiv="refresh" content="0; url=coverage/">
+          <a href="coverage/">Open coverage report</a>
+          HTML
 
       - name: Upload Pages artifact (coverage site)
         if: ${{ !env.ACT && matrix.node-version == '20.x' }}
@@ -79,7 +92,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
       - name: Add coverage link to summary
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && matrix.node-version == '20.x' }}
         run: |
           echo "### Coverage site" >> "$GITHUB_STEP_SUMMARY"
           echo "Browse: https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/coverage/" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: ${{ !env.ACT && matrix.node-version == '20.x' }}
         uses: actions/upload-pages-artifact@v3
         with:
-          path: coverage/lcov-report
+          path: site
 
       - name: Deploy coverage to GitHub Pages
         if: ${{ !env.ACT && matrix.node-version == '20.x' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,64 @@
+name: Node CI (Jest)
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test -- --ci --coverage
+
+      - name: Upload coverage report
+        if: ${{ !env.ACT }} # skip when running under act
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.node-version }}
+          path: |
+            coverage
+            junit.xml
+          if-no-files-found: ignore
+
+      - name: Summarize coverage in job summary
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -f coverage/coverage-summary.json ]; then
+            echo "coverage/coverage-summary.json not found; skipping summary" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const s = require('./coverage/coverage-summary.json');
+          const t = s.total;
+          const line = (k) => `- ${k}: ${t[k].pct}% (${t[k].covered}/${t[k].total})`;
+          console.log('### Coverage summary');
+          console.log(line('statements'));
+          console.log(line('branches'));
+          console.log(line('functions'));
+          console.log(line('lines'));
+          NODE
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,12 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -62,3 +68,18 @@ jobs:
           console.log(line('lines'));
           NODE
 
+      - name: Upload Pages artifact (coverage site)
+        if: ${{ !env.ACT }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: coverage/lcov-report
+
+      - name: Deploy coverage to GitHub Pages
+        if: ${{ !env.ACT }}
+        uses: actions/deploy-pages@v4
+
+      - name: Add coverage link to summary
+        if: ${{ !env.ACT }}
+        run: |
+          echo "### Coverage site" >> "$GITHUB_STEP_SUMMARY"
+          echo "Browse: https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/coverage/" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# TypeScript build & test output
+dist/
+build/
+coverage/
+
+# Jest cache
+.jest/
+jest-cache/
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,15 +1,33 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/opcodes', '<rootDir>'],
+
+  roots: ['<rootDir>'],
+
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+
   coverageReporters: ['text', 'lcov', 'json-summary'],
+
   collectCoverageFrom: [
     'opcodes/**/*.ts',
-    '!opcodes/**/*.d.ts',
-    '!opcodes/**/*.test.ts',
-    '*.ts',
-    '!*.test.ts',
-    '!*.d.ts',
+    '!**/*.d.ts',
+    '!**/*.(spec|test).ts',
   ],
+
+  coveragePathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/tszm.ts',
+  ],
+
+  // Start with global thresholds just below your “all files” numbers
+  coverageThreshold: {
+    global: {
+      statements: 72,
+      branches:   69,
+      functions:  50,
+      lines:      72,
+    },
+  },
 };
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/opcodes', '<rootDir>'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  coverageReporters: ['text', 'lcov', 'json-summary'],
   collectCoverageFrom: [
     'opcodes/**/*.ts',
     '!opcodes/**/*.d.ts',

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
     "build": "node build.mjs",
     "build:dev": "node build.mjs && chmod +x dist/tszm.js",
     "test": "jest",
+    "test:ci": "jest --ci --coverage",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
This PR adds a github action to run unit tests, and uploads the coverage report to github pages. You will need to set the repo's Pages source to "Github Actions" for this to work, but then the coverage report will be available at https://cshepherd.github.io/tszm/coverage/ .. example at https://clambertus.github.io/tszm/coverage/

You can gate PRs by enabling branch protection and setting "Require status checks to pass before merging" .. You can gate direct commits by enabling "Require a pull request before merging" under branch protection. 